### PR TITLE
add GeolocationPositionError message to reject value

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,8 +24,8 @@ const VueGeolocation = {
               accuracy: position.coords.accuracy
             })
           },
-          () => {
-            reject('no position access')
+          (e) => {
+            reject(e.message)
           },
           options
         )
@@ -53,8 +53,8 @@ const VueGeolocation = {
               speed: position.coords.speed
             })
           },
-          () => {
-            reject('no position access')
+          (e) => {
+            reject(e.message)
           },
           options
         )


### PR DESCRIPTION
Added `GeolocationPositionError `error message to reject value returned by `getLocation `and `watchLocation`.