### PR TITLE
ponytail: cut over-engineering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22]
-    name: node ${{ matrix.node }}
+    name: node 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run typecheck

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 # vue-browser-geolocation
 
-> Tiny, type-safe Geolocation for Vue 3 — a Promise-based plugin **and** a reactive `useGeolocation()` composable.
+> Tiny, type-safe Geolocation for Vue 3 — a reactive `useGeolocation()` composable and standalone Promise-based helpers.
 
 [![npm version](https://img.shields.io/npm/v/vue-browser-geolocation.svg)](https://www.npmjs.com/package/vue-browser-geolocation)
 [![CI](https://github.com/scaccogatto/vue-geolocation/actions/workflows/ci.yml/badge.svg)](https://github.com/scaccogatto/vue-geolocation/actions/workflows/ci.yml)
 [![minzipped size](https://img.shields.io/bundlephobia/minzip/vue-browser-geolocation)](https://bundlephobia.com/package/vue-browser-geolocation)
 [![license](https://img.shields.io/npm/l/vue-browser-geolocation.svg)](./LICENSE)
 
-- **Two ergonomic APIs** — a global plugin (`$getLocation` / `$watchLocation` / `$clearLocationWatch`) for the Options API, and a fully reactive `useGeolocation()` composable for `<script setup>`.
+- **Reactive composable** — `useGeolocation()` for `<script setup>`; auto-clears watches on unmount.
 - **Reactive streaming** — `coords` updates on _every_ position fix, not just the first.
 - **Real errors** — rejects with the full [`GeolocationPositionError`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError) so you can branch on `error.code`.
-- **Type-safe** — written in TypeScript, ships `.d.ts` and augments `ComponentCustomProperties`.
-- **Lightweight** — zero runtime dependencies, `vue` is a peer dependency. ESM + CJS + UMD builds.
+- **Type-safe** — written in TypeScript, ships `.d.ts`. ESM + CJS builds.
+- **Lightweight** — zero runtime dependencies, `vue` is a peer dependency.
 
 ## Install
 
@@ -63,31 +63,6 @@ watchLocation()
 | `watchLocation(options?)` | `number \| undefined` | Starts a watch, returns its `watchID`. |
 | `clearWatch()` | `void` | Stops the active watch. |
 
-## Plugin (Options API)
-
-```ts
-import { createApp } from 'vue'
-import VueGeolocation from 'vue-browser-geolocation'
-import App from './App.vue'
-
-createApp(App).use(VueGeolocation).mount('#app')
-```
-
-```ts
-// one-shot
-const coords = await this.$getLocation(options)
-
-// watch — pass an onUpdate callback to receive every fix
-const { watchID } = await this.$watchLocation(options, (coords) => {
-  console.log(coords)
-})
-
-// stop
-this.$clearLocationWatch(watchID)
-```
-
-> A bare `await this.$watchLocation()` resolves only once (a Promise can't yield more than one value). Pass the `onUpdate` callback for continuous updates, or use `useGeolocation()`.
-
 ## Standalone functions
 
 Everything is also importable directly, no Vue instance required:
@@ -128,17 +103,20 @@ await getLocation({}, true) // rejects
 await watchLocation({}, undefined, true) // rejects
 ```
 
+## Migrating from v2 (plugin API)
+
+v3 drops the `VueGeolocation` plugin and the `$getLocation / $watchLocation / $clearLocationWatch` global properties — use `useGeolocation()` or the standalone functions directly.
+
 ## Migrating from v1 (Vue 2)
 
-v2 is a TypeScript rewrite that targets **Vue 3 only**. Breaking changes:
+v2/v3 target **Vue 3 only**. Breaking changes from v1:
 
-| v1 (Vue 2) | v2 (Vue 3) |
+| v1 (Vue 2) | v3 (Vue 3) |
 | --- | --- |
-| `Vue.use(VueGeolocation)` | `createApp(App).use(VueGeolocation)` |
+| `Vue.use(VueGeolocation)` | use `useGeolocation()` composable |
 | `reject(error.message)` (string) | `reject(error)` — full `GeolocationPositionError`; read `error.code` |
-| `$watchLocation()` resolved once, no watchID | `$watchLocation(options, onUpdate)` resolves with `{ watchID, coordinates }` and streams via `onUpdate` ([#15](https://github.com/scaccogatto/vue-geolocation/issues/15)) |
-| `$clearLocationWatch(id)` returned a Promise | now returns `void` (throws if unsupported) |
-| no composable | new reactive `useGeolocation()` |
+| `$watchLocation()` resolved once | `watchLocation(options, onUpdate)` resolves with `{ watchID, coordinates }` and streams via `onUpdate` ([#15](https://github.com/scaccogatto/vue-geolocation/issues/15)) |
+| no composable | reactive `useGeolocation()` |
 | plain JS, no types | TypeScript, ships `.d.ts` |
 
 If you cannot migrate to Vue 3 yet, stay on `vue-browser-geolocation@1.8.0`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-browser-geolocation",
-  "version": "2.0.0",
-  "description": "Tiny, type-safe Geolocation wrapper for Vue 3 — a Promise-based plugin ($getLocation/$watchLocation) and a reactive useGeolocation() composable.",
+  "version": "3.0.0",
+  "description": "Tiny, type-safe Geolocation for Vue 3 — a reactive useGeolocation() composable and standalone Promise-based helpers.",
   "author": {
     "name": "Marco Boffo",
     "email": "marcoboffo.waves@gmail.com"
@@ -19,7 +19,6 @@
     "vue3",
     "geolocation",
     "composable",
-    "plugin",
     "typescript",
     "navigator",
     "coordinates"
@@ -29,8 +28,6 @@
   "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
-  "unpkg": "./dist/index.umd.cjs",
-  "jsdelivr": "./dist/index.umd.cjs",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
@@ -59,7 +56,6 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.0.1",
     "@vitest/coverage-v8": "^4.1.9",
-    "@vue/test-utils": "^2.4.11",
     "eslint": "^10.6.0",
     "jsdom": "^29.1.1",
     "typescript": "^6.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import {
   getCurrentScope,
   onScopeDispose,
   ref,
-  type App,
   type Ref,
 } from 'vue'
 
@@ -240,34 +239,5 @@ export const useGeolocation = (
     getLocation: get,
     watchLocation: watch,
     clearWatch: clear,
-  }
-}
-
-/**
- * Vue 3 plugin. Registers the Promise-based helpers as global properties:
- * `$getLocation`, `$watchLocation`, `$clearLocationWatch`.
- *
- * @example
- * ```ts
- * import { createApp } from 'vue'
- * import VueGeolocation from 'vue-browser-geolocation'
- * createApp(App).use(VueGeolocation).mount('#app')
- * ```
- */
-export const VueGeolocation = {
-  install(app: App): void {
-    app.config.globalProperties.$getLocation = getLocation
-    app.config.globalProperties.$watchLocation = watchLocation
-    app.config.globalProperties.$clearLocationWatch = clearWatch
-  },
-}
-
-export default VueGeolocation
-
-declare module 'vue' {
-  interface ComponentCustomProperties {
-    $getLocation: typeof getLocation
-    $watchLocation: typeof watchLocation
-    $clearLocationWatch: typeof clearWatch
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,7 +1,6 @@
-import { mount } from '@vue/test-utils'
-import { effectScope, nextTick, defineComponent, h } from 'vue'
+import { effectScope } from 'vue'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import VueGeolocation, {
+import {
   clearWatch,
   getLocation,
   GeolocationForcedRejectError,
@@ -259,30 +258,5 @@ describe('useGeolocation', () => {
     })
     scope.stop()
     restore()
-  })
-})
-
-describe('Vue plugin', () => {
-  it('registers global properties via app.use', async () => {
-    harness.setCurrentPosition({
-      type: 'success',
-      position: makePosition({ latitude: 99 }),
-    })
-    let captured: Coordinates | null = null
-    const Comp = defineComponent({
-      async mounted() {
-        captured = await this.$getLocation()
-      },
-      render: () => h('div'),
-    })
-    const wrapper = mount(Comp, { global: { plugins: [VueGeolocation] } })
-    const vm = wrapper.vm as unknown as Record<string, unknown>
-    expect(typeof vm.$getLocation).toBe('function')
-    expect(typeof vm.$watchLocation).toBe('function')
-    expect(typeof vm.$clearLocationWatch).toBe('function')
-    await new Promise((r) => queueMicrotask(() => r(null)))
-    await nextTick()
-    expect(captured).toMatchObject({ lat: 99 })
-    wrapper.unmount()
   })
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,21 +13,13 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(import.meta.dirname, 'src/index.ts'),
-      name: 'VueGeolocation',
-      formats: ['es', 'cjs', 'umd'],
-      fileName: (format) =>
-        format === 'es'
-          ? 'index.mjs'
-          : format === 'umd'
-            ? 'index.umd.cjs'
-            : 'index.cjs',
+      // ponytail: no UMD — ESM covers bundlers, CJS keeps Node require() alive
+      formats: ['es', 'cjs'],
+      fileName: (format) => (format === 'es' ? 'index.mjs' : 'index.cjs'),
     },
     rolldownOptions: {
       external: ['vue'],
-      output: {
-        exports: 'named',
-        globals: { vue: 'Vue' },
-      },
+      output: { exports: 'named' },
     },
   },
   test: {


### PR DESCRIPTION
## What was cut

| Cut | Category | Reason |
|---|---|---|
| UMD build format + `unpkg`/`jsdelivr` package.json fields | Build output | CDN-legacy; ESM covers bundlers, CJS covers Node `require()` — zero CDN-direct consumers expected for a Vue 3 composable lib |
| `VueGeolocation` plugin (`$getLocation`, `$watchLocation`, `$clearLocationWatch` global props) + `declare module 'vue'` augmentation | API surface | Pure `globalProperties` sugar with no config injection; `useGeolocation()` + standalone fns cover every use-case in the Vue 3 idiom |
| `@vue/test-utils` devDep | Dependencies | Only used by the now-deleted plugin test |
| CI Node matrix `[20, 22]` → single Node 20 LTS | CI | Node 22 adds no coverage for this library; saves one full CI run per push |

**Net diff: −117 additions, +23, 6 files changed.** devDeps: 12 → 11. Build outputs: 3 → 2.

## What was deliberately kept

- CJS build — ponytail: CJS stays; published lib must not break Node `require()` consumers
- All composable and standalone-function tests (24/25 — only the plugin integration test was removed)
- `tsconfig.json` — already a single minimal config, nothing to collapse
- ESLint config and `lint` script — real quality gate, no git hooks driving it

## Breaking changes

- **v3.0.0** — `VueGeolocation` default export and `$getLocation / $watchLocation / $clearLocationWatch` global properties removed. Migrate: use `useGeolocation()` or the standalone `getLocation / watchLocation / clearWatch` imports.

## Gate

```
typecheck  ✓
lint       ✓
test       ✓  24/24 (25 before — 1 plugin test removed)
build      ✓  dist/index.mjs 2.16 kB │ dist/index.cjs 1.75 kB
```

https://claude.ai/code/session_01NXBkkU4ArQJH2CASi3VmhC