### PR TITLE
ci: SHA-pin fetch-metadata + align ci.yml with vue-viewports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,25 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: node 24
+    name: Node 24
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: npm
+
       - run: npm ci
-      - run: npm run typecheck
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm run coverage
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: dependabot/fetch-metadata@v3
+      - uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         id: metadata
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Consistency pass to match the sibling `vue-viewports` repo:

- **SHA-pin** `dependabot/fetch-metadata@v3` → `25dd0e34` (v3.1.0), consistent with the already-pinned `checkout`/`setup-node`.
- **ci.yml**: named steps (Lint/Typecheck/Test/Build), `npm run coverage` (provider already present, runs locally at 97%), job name `Node 24`, matching step order/spacing.

https://claude.ai/code/session_01JkPiYPmw3bPCFGv8EYAbp8