### PR TITLE
feat: demo app pubblicata su GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Pages
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - run: npm run build-demo -- --base=/${{ github.event.repository.name }}/
+
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: dist
+
+      - id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![minzipped size](https://img.shields.io/bundlephobia/minzip/vue-browser-geolocation)](https://bundlephobia.com/package/vue-browser-geolocation)
 [![license](https://img.shields.io/npm/l/vue-browser-geolocation.svg)](./LICENSE)
 
+[Live demo](https://scaccogatto.github.io/vue-geolocation/) — ask for a fix, watch position updates, measure the distance travelled.
+
 - **Reactive composable** — `useGeolocation()` for `<script setup>`; auto-clears watches on unmount.
 - **Reactive streaming** — `coords` updates on _every_ position fix, not just the first.
 - **Real errors** — rejects with the full [`GeolocationPositionError`](https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPositionError) so you can branch on `error.code`.

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  distanceBetween,
+  isSupported,
+  useGeolocation,
+  type Coordinates,
+} from 'vue-geolocation'
+
+const { coords, error, isWatching, getLocation, watchLocation, clearWatch } =
+  useGeolocation({ enableHighAccuracy: true })
+
+const supported = isSupported()
+const pending = ref(false)
+const firstFix = ref<Coordinates | null>(null)
+
+const fetchOnce = async () => {
+  pending.value = true
+  try {
+    const value = await getLocation()
+    firstFix.value ??= value
+  } catch {
+    // The error ref already carries it — nothing to add here.
+  } finally {
+    pending.value = false
+  }
+}
+
+const startWatch = () => {
+  firstFix.value ??= coords.value
+  watchLocation()
+}
+
+// Distance travelled since the first fix of this session.
+const travelled = computed(() =>
+  firstFix.value && coords.value
+    ? Math.round(distanceBetween(firstFix.value, coords.value))
+    : null,
+)
+
+const rows = computed(() =>
+  coords.value
+    ? (Object.entries(coords.value) as [string, number | null][])
+    : [],
+)
+</script>
+
+<template>
+  <main>
+    <h1>vue-geolocation</h1>
+    <p class="lede">
+      A reactive wrapper around the browser Geolocation API. Your browser will
+      ask for permission; nothing is sent anywhere, the coordinates stay in this
+      page.
+    </p>
+
+    <p v-if="!supported" class="error">
+      This browser exposes no Geolocation API.
+    </p>
+
+    <div class="actions">
+      <button type="button" :disabled="!supported || pending" @click="fetchOnce">
+        {{ pending ? 'Locating…' : 'getLocation()' }}
+      </button>
+      <button
+        type="button"
+        :disabled="!supported || isWatching"
+        @click="startWatch"
+      >
+        watchLocation()
+      </button>
+      <button type="button" :disabled="!isWatching" @click="clearWatch">
+        clearWatch()
+      </button>
+      <span class="label">{{ isWatching ? 'watching' : 'idle' }}</span>
+    </div>
+
+    <p v-if="error" class="error">
+      <code>{{ error.name || 'GeolocationPositionError' }}</code>
+      — {{ error.message }}
+    </p>
+
+    <table v-if="rows.length">
+      <tbody>
+        <tr v-for="[key, value] in rows" :key="key">
+          <th>{{ key }}</th>
+          <td>{{ value ?? '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else class="muted">No fix yet.</p>
+
+    <h2>distanceBetween</h2>
+    <p>
+      Great-circle distance from the first fix of this session:
+      <strong v-if="travelled !== null">{{ travelled }} m</strong>
+      <span v-else class="muted">waiting for a second fix</span>
+    </p>
+  </main>
+</template>
+
+<style scoped>
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  padding: 0.4rem 0.5rem 0.4rem 0;
+  text-align: left;
+  border-bottom: 1px solid var(--line);
+}
+
+th {
+  width: 12rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+td {
+  font-family: var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.error {
+  color: #b91c1c;
+}
+
+@media (prefers-color-scheme: dark) {
+  .error {
+    color: #fca5a5;
+  }
+}
+
+.muted {
+  color: var(--muted);
+}
+</style>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>vue-geolocation</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/demo/main.ts
+++ b/demo/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './style.css'
+
+createApp(App).mount('#app')

--- a/demo/style.css
+++ b/demo/style.css
@@ -1,0 +1,82 @@
+:root {
+  color-scheme: light dark;
+  --bg: #fbfbfa;
+  --fg: #1a1a1a;
+  --muted: #6b6b6b;
+  --line: #e2e2df;
+  --accent: #0f766e;
+  --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #131315;
+    --fg: #ededeb;
+    --muted: #9a9a97;
+    --line: #2c2c30;
+    --accent: #5eead4;
+  }
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.6 ui-sans-serif, system-ui, sans-serif;
+}
+
+code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+}
+
+main {
+  max-width: 44rem;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 4rem;
+}
+
+h1 {
+  margin: 0 0 0.25rem;
+  font-family: var(--mono);
+  font-size: 1.5rem;
+}
+
+h2 {
+  margin: 2.5rem 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.lede {
+  margin: 0 0 2rem;
+  color: var(--muted);
+}
+
+.label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+button {
+  font: inherit;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: transparent;
+  color: var(--fg);
+  cursor: pointer;
+}
+
+button:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ export default tseslint.config(
     languageOptions: {
       parserOptions: {
         projectService: {
-          allowDefaultProject: ['eslint.config.js'],
+          allowDefaultProject: ['eslint.config.js', 'vite.config.demo.ts', 'demo/main.ts'],
         },
         tsconfigRootDir: import.meta.dirname,
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@types/node": "^26.0.1",
+        "@vitejs/plugin-vue": "^6.0.8",
         "@vitest/coverage-v8": "^4.1.9",
         "eslint": "^10.6.0",
         "jsdom": "^30.0.1",
@@ -1199,6 +1200,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "6.0.8",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-6.0.8.tgz",
+      "integrity": "sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "vue": "^3.2.25"
       }
     },
     "node_modules/@vitest/coverage-v8": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint .",
-    "prepublishOnly": "npm run typecheck && npm run test && npm run build"
+    "prepublishOnly": "npm run typecheck && npm run test && npm run build",
+    "build-demo": "vite build --config vite.config.demo.ts",
+    "dev-demo": "vite --config vite.config.demo.ts"
   },
   "peerDependencies": {
     "vue": "^3.2.25"
@@ -58,6 +60,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@types/node": "^26.0.1",
+    "@vitejs/plugin-vue": "^6.0.8",
     "@vitest/coverage-v8": "^4.1.9",
     "eslint": "^10.6.0",
     "jsdom": "^30.0.1",

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -1,0 +1,20 @@
+import { resolve } from 'node:path'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+
+// Demo app published on GitHub Pages. The library itself is built by
+// vite.config.ts; here we only bundle demo/, aliasing the package name to the
+// sources so the demo reads exactly like real consumer code.
+export default defineConfig({
+  root: resolve(import.meta.dirname, 'demo'),
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      'vue-geolocation': resolve(import.meta.dirname, 'src/index.ts'),
+    },
+  },
+  build: {
+    outDir: resolve(import.meta.dirname, 'dist'),
+    emptyOutDir: true,
+  },
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig({
     dts({
       include: ['src'],
       tsconfigPath: './tsconfig.json',
+      // Library sources are pure TS. Without this, unplugin-dts finds
+      // demo/App.vue while scanning the root and switches to the Vue
+      // processor, which needs @vue/language-core.
+      processor: 'ts',
     }),
   ],
   build: {


### PR DESCRIPTION
Aggiunge una demo app a questo repo e la pubblica su GitHub Pages, come gia' fatto per vue-waypoint.

- `demo/`: app Vite separata (index.html + App.vue + main.ts + style.css condiviso tra i repo).
- `vite.config.demo.ts`: compila solo `demo/`, con il nome del pacchetto aliasato a `src/index.ts`, cosi' la demo si legge come codice di un consumatore vero. La build della libreria (`vite.config.ts`) non cambia.
- `.github/workflows/pages.yml`: deploy su Pages a ogni push su master; il base path viene da `github.event.repository.name`, quindi il file e' identico su tutti i repo.
- `processor: 'ts'` esplicito nelle opzioni dts: senza, unplugin-dts trova `demo/App.vue` scansionando il root, passa al processor Vue e fallisce su `@vue/language-core` (che non e' installato). I sorgenti della libreria restano TS puro.
- README: link alla demo.

Verifica: lint, typecheck, coverage, build della libreria e build della demo verdi in locale; ogni demo caricata in Chrome e testata a mano (render, reattivita', zero errori in console).