### PR TITLE
chore: typecheck e build della demo in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Build demo
+        run: npm run build-demo

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -5,7 +5,7 @@ import {
   isSupported,
   useGeolocation,
   type Coordinates,
-} from 'vue-geolocation'
+} from 'vue-browser-geolocation'
 
 const { coords, error, isWatching, getLocation, watchLocation, clearWatch } =
   useGeolocation({ enableHighAccuracy: true })
@@ -37,6 +37,16 @@ const travelled = computed(() =>
     ? Math.round(distanceBetween(firstFix.value, coords.value))
     : null,
 )
+
+// GeolocationPositionError carries a numeric `code`, the library's own errors
+// are Error subclasses with a `name` — the union has no field in common.
+const errorLabel = computed(() => {
+  const caught = error.value
+  if (!caught) return null
+  return 'name' in caught
+    ? caught.name
+    : `GeolocationPositionError (code ${caught.code})`
+})
 
 const rows = computed(() =>
   coords.value
@@ -76,8 +86,7 @@ const rows = computed(() =>
     </div>
 
     <p v-if="error" class="error">
-      <code>{{ error.name || 'GeolocationPositionError' }}</code>
-      — {{ error.message }}
+      <code>{{ errorLabel }}</code> — {{ error.message }}
     </p>
 
     <table v-if="rows.length">

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "vite": "^8.1.0",
         "vite-plugin-dts": "^5.0.3",
         "vitest": "^4.1.9",
-        "vue": "^3.5.39"
+        "vue": "^3.5.39",
+        "vue-tsc": "^3.3.9"
       },
       "engines": {
         "node": ">=20"
@@ -1373,6 +1374,22 @@
         "@vue/shared": "3.5.41"
       }
     },
+    "node_modules/@vue/language-core": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.9.tgz",
+      "integrity": "sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.28",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^3.2.1",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1",
+        "picomatch": "^4.0.4"
+      }
+    },
     "node_modules/@vue/reactivity": {
       "version": "3.5.41",
       "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
@@ -1465,6 +1482,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/alien-signals": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
+      "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2642,6 +2666,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -3512,6 +3543,23 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.9.tgz",
+      "integrity": "sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.28",
+        "@vue/language-core": "3.3.9"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -45,14 +45,15 @@
   ],
   "scripts": {
     "build": "vite build",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck-demo",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",
     "lint": "eslint .",
     "prepublishOnly": "npm run typecheck && npm run test && npm run build",
     "build-demo": "vite build --config vite.config.demo.ts",
-    "dev-demo": "vite --config vite.config.demo.ts"
+    "dev-demo": "vite --config vite.config.demo.ts",
+    "typecheck-demo": "vue-tsc --noEmit -p tsconfig.demo.json"
   },
   "peerDependencies": {
     "vue": "^3.2.25"
@@ -69,7 +70,8 @@
     "vite": "^8.1.0",
     "vite-plugin-dts": "^5.0.3",
     "vitest": "^4.1.9",
-    "vue": "^3.5.39"
+    "vue": "^3.5.39",
+    "vue-tsc": "^3.3.9"
   },
   "engines": {
     "node": ">=20"

--- a/tsconfig.demo.json
+++ b/tsconfig.demo.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "types": ["node", "vite/client"],
+    "strict": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "paths": {
+      "vue-browser-geolocation": ["./src/index.ts"]
+    }
+  },
+  "include": ["demo/**/*.ts", "demo/**/*.vue", "vite.config.demo.ts"]
+}

--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   plugins: [vue()],
   resolve: {
     alias: {
-      'vue-geolocation': resolve(import.meta.dirname, 'src/index.ts'),
+      'vue-browser-geolocation': resolve(import.meta.dirname, 'src/index.ts'),
     },
   },
   build: {


### PR DESCRIPTION
Le demo aggiunte non erano coperte da nessun check: `tsc` non sa leggere gli SFC, e `build-demo` girava solo nel workflow Pages, cioe' **dopo** il merge.

- `tsconfig.demo.json` + `vue-tsc`: lo script `typecheck` ora copre anche `demo/` e `vite.config.demo.ts`. Il `paths` rispecchia l'alias di Vite, quindi la demo si typechecka contro i sorgenti veri della libreria.
- step "Build demo" in `ci.yml`: una demo rotta ora blocca la PR invece di rompere il deploy su master.

Il typecheck ha ripagato subito, con due problemi che erano gia' in produzione:
- `vue-geolocation`: la demo leggeva `error.name`, che su `GeolocationPositionError` non esiste (ha `code` numerico). Ora distingue i due rami dell'union.
- `vue-geolocation`: la demo importava da `vue-geolocation` (nome del repo) invece che da `vue-browser-geolocation` (nome del pacchetto pubblicato).
- `@types/node` aggiunto dove mancava (smooth-vuebar, vue-viewports).

Verifica: lint, typecheck, coverage, build libreria e build demo verdi in locale su tutti i repo; percorso di errore e di successo della demo geolocation ricontrollati in Chrome.